### PR TITLE
feat: ignore changes to admin password

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,13 @@ resource "azurerm_mssql_server" "this" {
     login_username = var.azuread_admin_login
     object_id      = var.azuread_admin_object_id
   }
+
+  lifecycle {
+    ignore_changes = [
+      # Allow admin password to be updated outside of Terraform.
+      administrator_login_password
+    ]
+  }
 }
 
 resource "azurerm_mssql_firewall_rule" "this" {

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -9,6 +9,10 @@ locals {
 
 data "azurerm_client_config" "current" {}
 
+data "http" "public_ip" {
+  url = "https://ifconfig.me"
+}
+
 resource "random_id" "this" {
   byte_length = 8
 }
@@ -30,11 +34,9 @@ module "sql" {
   resource_group_name = azurerm_resource_group.this.name
 
   azuread_admin_login     = "john.smith@example.com"
-  azuread_admin_object_id = data.azurerm_client_config.current.object_id # Must be a real object ID within the current tenant.
+  azuread_admin_object_id = data.azurerm_client_config.current.object_id
 
   firewall_rules = {
-    "Rule1" = ["1.1.1.1", "1.1.1.1"]
-    "Rule2" = ["2.2.2.2", "2.2.2.2"]
-    "Rule3" = ["3.3.3.3", "3.3.3.3"]
+    "AllowClientPublicIp" = [data.http.public_ip.body, data.http.public_ip.body]
   }
 }


### PR DESCRIPTION
Ignore changes to admin password to support automatic password rotation outside of Terraform. 