### PR TITLE
refactor!: update variables and outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_admin_login"></a> [admin\_login](#input\_admin\_login) | The login username of the administrator of this SQL server. | `string` | n/a | yes |
 | <a name="input_azuread_admin"></a> [azuread\_admin](#input\_azuread\_admin) | The user principal name (or group name) and object ID of the Azure AD administrator of this SQL server. | <pre>object({<br>    user_principal_name = string<br>    object_id           = string<br>  })</pre> | `null` | no |
 | <a name="input_firewall_rules"></a> [firewall\_rules](#input\_firewall\_rules) | A map of IP address ranges that should be able to access this SQL Server. | `map(tuple([string, string]))` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The supported Azure location where the resources exist. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -91,14 +91,12 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_application"></a> [application](#input\_application) | The application to create the resources for. | `string` | n/a | yes |
 | <a name="input_azuread_admin"></a> [azuread\_admin](#input\_azuread\_admin) | The user principal name (or group name) and object ID of the Azure AD administrator of this SQL server. | <pre>object({<br>    user_principal_name = string<br>    object_id           = string<br>  })</pre> | `null` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | The environment to create the resources for. | `string` | n/a | yes |
 | <a name="input_firewall_rules"></a> [firewall\_rules](#input\_firewall\_rules) | A map of IP address ranges that should be able to access this SQL Server. | `map(tuple([string, string]))` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The supported Azure location where the resources exist. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group in which to create the resources. | `string` | n/a | yes |
-| <a name="input_server_name"></a> [server\_name](#input\_server\_name) | A custom name for this SQL server. | `string` | `null` | no |
-| <a name="input_storage_account_name"></a> [storage\_account\_name](#input\_storage\_account\_name) | A custom name for the Storage Account. | `string` | `null` | no |
+| <a name="input_server_name"></a> [server\_name](#input\_server\_name) | The name of this SQL server. | `string` | n/a | yes |
+| <a name="input_storage_account_name"></a> [storage\_account\_name](#input\_storage\_account\_name) | The name of this Storage account. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to the resources. | `map(string)` | `{}` | no |
 
 ## Outputs
@@ -107,8 +105,8 @@ No modules.
 |------|-------------|
 | <a name="output_admin_login"></a> [admin\_login](#output\_admin\_login) | The login username of the administrator of this SQL server. |
 | <a name="output_admin_password"></a> [admin\_password](#output\_admin\_password) | The login password of the administrator of this SQL server. |
-| <a name="output_server_id"></a> [server\_id](#output\_server\_id) | The ID of the SQL Server. |
-| <a name="output_server_name"></a> [server\_name](#output\_server\_name) | The name of the SQL Server. |
-| <a name="output_storage_account_id"></a> [storage\_account\_id](#output\_storage\_account\_id) | The ID of the Storage Account. |
-| <a name="output_storage_account_name"></a> [storage\_account\_name](#output\_storage\_account\_name) | The name of the Storage Account. |
+| <a name="output_server_id"></a> [server\_id](#output\_server\_id) | The ID of this SQL Server. |
+| <a name="output_server_name"></a> [server\_name](#output\_server\_name) | The name of this SQL Server. |
+| <a name="output_storage_account_id"></a> [storage\_account\_id](#output\_storage\_account\_id) | The ID of this Storage Account. |
+| <a name="output_storage_account_name"></a> [storage\_account\_name](#output\_storage\_account\_name) | The name of this Storage Account. |
 <!-- END_TF_DOCS -->

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,5 @@
-locals {
-  suffix       = "${var.application}-${var.environment}"
-  suffix_alnum = join("", regexall("[a-z0-9]", lower(local.suffix)))
-
-  tags = merge({ application = var.application, environment = var.environment }, var.tags)
-}
-
 resource "azurerm_storage_account" "this" {
-  name                = coalesce(var.storage_account_name, "stsql${local.suffix_alnum}")
+  name                = var.storage_account_name
   location            = var.location
   resource_group_name = var.resource_group_name
 
@@ -20,7 +13,7 @@ resource "azurerm_storage_account" "this" {
   shared_access_key_enabled       = true
   allow_nested_items_to_be_public = false
 
-  tags = local.tags
+  tags = var.tags
 
   blob_properties {
     delete_retention_policy {
@@ -42,7 +35,7 @@ resource "random_password" "this" {
 }
 
 resource "azurerm_mssql_server" "this" {
-  name                         = coalesce(var.server_name, "sql-${local.suffix}")
+  name                         = var.server_name
   location                     = var.location
   resource_group_name          = var.resource_group_name
   version                      = "12.0"
@@ -50,7 +43,7 @@ resource "azurerm_mssql_server" "this" {
   administrator_login_password = random_password.this.result
   minimum_tls_version          = "1.2"
 
-  tags = local.tags
+  tags = var.tags
 
   dynamic "azuread_administrator" {
     for_each = var.azuread_admin != null ? [var.azuread_admin] : []

--- a/main.tf
+++ b/main.tf
@@ -30,8 +30,15 @@ resource "azurerm_storage_account" "this" {
 }
 
 resource "random_password" "this" {
-  length  = 32
-  special = true
+  length      = 128
+  lower       = true
+  upper       = true
+  numeric     = true
+  special     = true
+  min_lower   = 1
+  min_upper   = 1
+  min_numeric = 1
+  min_special = 1
 }
 
 resource "azurerm_mssql_server" "this" {
@@ -39,7 +46,7 @@ resource "azurerm_mssql_server" "this" {
   location                     = var.location
   resource_group_name          = var.resource_group_name
   version                      = "12.0"
-  administrator_login          = "sql${local.suffix_alnum}"
+  administrator_login          = var.admin_login
   administrator_login_password = random_password.this.result
   minimum_tls_version          = "1.2"
 

--- a/modules/database/README.md
+++ b/modules/database/README.md
@@ -30,13 +30,11 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_application"></a> [application](#input\_application) | The application to create the resources for. | `string` | n/a | yes |
-| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | A custom name for this SQL database. | `string` | `null` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | The environment to create the resources for. | `string` | n/a | yes |
 | <a name="input_ltr_monthly_retention"></a> [ltr\_monthly\_retention](#input\_ltr\_monthly\_retention) | The duration that monthly long-term backups should be retained. Value must be in an ISO 8601 duration format, e.g. `P1Y`, `P1M`, `P4W` or `P30D`. | `string` | `"PT0S"` | no |
 | <a name="input_ltr_week_of_year"></a> [ltr\_week\_of\_year](#input\_ltr\_week\_of\_year) | The week of year to take the yearly long-term backup. Value must be between `1` and `52`. | `number` | `1` | no |
 | <a name="input_ltr_weekly_retention"></a> [ltr\_weekly\_retention](#input\_ltr\_weekly\_retention) | The duration that weekly long-term backups should be retained. Value must be in an ISO 8601 duration format, e.g. `P1Y`, `P1M`, `P1W` or `P7D`. | `string` | `"P1M"` | no |
 | <a name="input_ltr_yearly_retention"></a> [ltr\_yearly\_retention](#input\_ltr\_yearly\_retention) | The duration that yearly long-term backups should be retained. Value must be in an ISO 8601 duration format, e.g. `P1Y`, `P12M`, `P52W` or `P365D` | `string` | `"PT0S"` | no |
+| <a name="input_name"></a> [name](#input\_name) | A custom name for this SQL database. | `string` | n/a | yes |
 | <a name="input_pitr_retention_days"></a> [pitr\_retention\_days](#input\_pitr\_retention\_days) | The number of days that point-in-time restore backups should be retained. Value must be between `7` and `35` | `number` | `7` | no |
 | <a name="input_server_id"></a> [server\_id](#input\_server\_id) | The ID of the SQL server to create this SQL database in. | `string` | n/a | yes |
 | <a name="input_sku_name"></a> [sku\_name](#input\_sku\_name) | The SKU name of this SQL database. | `string` | `"Basic"` | no |
@@ -47,6 +45,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_database_id"></a> [database\_id](#output\_database\_id) | The ID of this SQL database. |
-| <a name="output_database_name"></a> [database\_name](#output\_database\_name) | The name of this SQL database. |
+| <a name="output_id"></a> [id](#output\_id) | The ID of this SQL database. |
+| <a name="output_name"></a> [name](#output\_name) | The name of this SQL database. |
 <!-- END_TF_DOCS -->

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -1,9 +1,5 @@
-locals {
-  database_name = replace(lower("sqldb-${var.application}-${var.environment}"), "/[^a-z0-9-]+/", "")
-}
-
 resource "azurerm_mssql_database" "this" {
-  name                 = coalesce(var.database_name, local.database_name)
+  name                 = var.name
   server_id            = var.server_id
   sku_name             = var.sku_name
   storage_account_type = var.storage_account_type
@@ -20,11 +16,5 @@ resource "azurerm_mssql_database" "this" {
     week_of_year      = var.ltr_week_of_year
   }
 
-  tags = merge(
-    {
-      application = var.application
-      environment = var.environment
-    },
-    var.tags
-  )
+  tags = var.tags
 }

--- a/modules/database/outputs.tf
+++ b/modules/database/outputs.tf
@@ -1,9 +1,9 @@
-output "database_id" {
+output "id" {
   description = "The ID of this SQL database."
   value       = azurerm_mssql_database.this.id
 }
 
-output "database_name" {
+output "name" {
   description = "The name of this SQL database."
   value       = azurerm_mssql_database.this.name
 }

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -1,14 +1,4 @@
-variable "application" {
-  description = "The application to create the resources for."
-  type        = string
-}
-
-variable "environment" {
-  description = "The environment to create the resources for."
-  type        = string
-}
-
-variable "database_name" {
+variable "name" {
   description = "A custom name for this SQL database."
   type        = string
   default     = null

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -1,7 +1,6 @@
 variable "name" {
   description = "A custom name for this SQL database."
   type        = string
-  default     = null
 }
 
 variable "server_id" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,20 +1,10 @@
-output "storage_account_id" {
-  description = "The ID of the Storage Account."
-  value       = azurerm_storage_account.this.id
-}
-
-output "storage_account_name" {
-  description = "The name of the Storage Account."
-  value       = azurerm_storage_account.this.name
-}
-
 output "server_id" {
-  description = "The ID of the SQL Server."
+  description = "The ID of this SQL Server."
   value       = azurerm_mssql_server.this.id
 }
 
 output "server_name" {
-  description = "The name of the SQL Server."
+  description = "The name of this SQL Server."
   value       = azurerm_mssql_server.this.name
 }
 
@@ -27,4 +17,14 @@ output "admin_password" {
   description = "The login password of the administrator of this SQL server."
   value       = azurerm_mssql_server.this.administrator_login_password
   sensitive   = true
+}
+
+output "storage_account_id" {
+  description = "The ID of this Storage Account."
+  value       = azurerm_storage_account.this.id
+}
+
+output "storage_account_name" {
+  description = "The name of this Storage Account."
+  value       = azurerm_storage_account.this.name
 }

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -20,6 +20,7 @@ module "sql" {
   resource_group_name  = azurerm_resource_group.this.name
   location             = azurerm_resource_group.this.location
   storage_account_name = "${random_id.this.hex}sqlst"
+  admin_login          = "masterlogin"
 
   azuread_admin = {
     user_principal_name = "john.smith@example.com"

--- a/test/fixture/main.tf
+++ b/test/fixture/main.tf
@@ -2,34 +2,24 @@ provider "azurerm" {
   features {}
 }
 
-locals {
-  application = random_id.this.hex
-  environment = "test"
-}
-
 data "azurerm_client_config" "current" {}
-
-data "http" "public_ip" {
-  url = "https://ifconfig.me"
-}
 
 resource "random_id" "this" {
   byte_length = 8
 }
 
 resource "azurerm_resource_group" "this" {
-  name     = "rg-${local.application}-${local.environment}"
+  name     = "${random_id.this.hex}-rg"
   location = var.location
 }
 
 module "sql" {
   source = "../.."
 
-  application          = local.application
-  environment          = local.environment
-  storage_account_name = "st${local.application}sql001"
-  location             = azurerm_resource_group.this.location
+  server_name          = "${random_id.this.hex}-sql"
   resource_group_name  = azurerm_resource_group.this.name
+  location             = azurerm_resource_group.this.location
+  storage_account_name = "${random_id.this.hex}sqlst"
 
   azuread_admin = {
     user_principal_name = "john.smith@example.com"
@@ -37,14 +27,15 @@ module "sql" {
   }
 
   firewall_rules = {
-    "AllowClientPublicIp" = [data.http.public_ip.body, data.http.public_ip.body]
+    "Rule1" = ["1.1.1.1", "1.1.1.1"],
+    "Rule2" = ["1.1.1.1", "1.1.1.1"],
+    "Rule3" = ["1.1.1.1", "1.1.1.1"]
   }
 }
 
 module "database" {
   source = "../../modules/database"
 
-  application = local.application
-  environment = local.environment
-  server_id   = module.sql.server_id
+  name      = "${random_id.this.hex}-sqldb"
+  server_id = module.sql.server_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,11 @@ variable "storage_account_name" {
   type        = string
 }
 
+output "admin_login" {
+  description = "The login username of the administrator of this SQL server."
+  type        = string
+}
+
 variable "azuread_admin" {
   description = "The user principal name (or group name) and object ID of the Azure AD administrator of this SQL server."
   type = object({

--- a/variables.tf
+++ b/variables.tf
@@ -1,17 +1,6 @@
-variable "application" {
-  description = "The application to create the resources for."
+variable "server_name" {
+  description = "The name of this SQL server."
   type        = string
-}
-
-variable "environment" {
-  description = "The environment to create the resources for."
-  type        = string
-}
-
-variable "storage_account_name" {
-  description = "A custom name for the Storage Account."
-  type        = string
-  default     = null
 }
 
 variable "location" {
@@ -24,16 +13,9 @@ variable "resource_group_name" {
   type        = string
 }
 
-variable "tags" {
-  description = "A mapping of tags to assign to the resources."
-  type        = map(string)
-  default     = {}
-}
-
-variable "server_name" {
-  description = "A custom name for this SQL server."
+variable "storage_account_name" {
+  description = "The name of this Storage account."
   type        = string
-  default     = null
 }
 
 variable "azuread_admin" {
@@ -48,4 +30,10 @@ variable "azuread_admin" {
 variable "firewall_rules" {
   description = "A map of IP address ranges that should be able to access this SQL Server."
   type        = map(tuple([string, string]))
+}
+
+variable "tags" {
+  description = "A mapping of tags to assign to the resources."
+  type        = map(string)
+  default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "storage_account_name" {
   type        = string
 }
 
-output "admin_login" {
+variable "admin_login" {
   description = "The login username of the administrator of this SQL server."
   type        = string
 }


### PR DESCRIPTION
Remove variables `application` and `environment`. Names and tags should be explicitly set.

BREAKING CHANGE: remove variable `application`

BREAKING CHANGE: remove variable `environment`

BREAKING CHANGE: remove variable `server_name` default value

BREAKING CHANGE: remove variable `storage_account_name` default value

BREAKING CHANGE: add variable `admin_login`

BREAKING CHANGE: remove variable `application` in sub-module `database`

BREAKING CHANGE: remove variable `environment` in sub-module `database`

BREAKING CHANGE: rename variable `database_name` to `name` in sub-module `database`

BREAKING CHANGE: rename output `database_name` to `name` in sub-module `database`

BREAKING CHANGE: rename output `database_id` to `id` in sub-module `database`