### PR TITLE
refactor(database): set str backup interval as a variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -130,6 +130,7 @@ module "database" {
   ltr_monthly_retention = each.value.ltr_monthly_retention
   ltr_yearly_retention  = each.value.ltr_yearly_retention
   ltr_week_of_year      = each.value.ltr_week_of_year
+  str_backup_interval   = each.value.str_backup_interval
 
   tags = var.tags
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -6,7 +6,7 @@ resource "azurerm_mssql_database" "this" {
 
   short_term_retention_policy {
     retention_days           = var.pitr_retention_days
-    backup_interval_in_hours = 12
+    backup_interval_in_hours = var.str_backup_interval
   }
 
   long_term_retention_policy {

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -28,6 +28,13 @@ variable "pitr_retention_days" {
   nullable    = false
 }
 
+variable "str_backup_interval" {
+  description = "The hours between each differential backup. Value has to be 12 or 24, defaults to 12 hours."
+  type        = number
+  default     = 12
+  nullable    = false
+}
+
 variable "ltr_weekly_retention" {
   description = "The duration that weekly long-term backups should be retained. Value must be in an ISO 8601 duration format, e.g. `P1Y`, `P1M`, `P1W` or `P7D`."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,7 @@ variable "databases" {
     ltr_monthly_retention = optional(string)
     ltr_yearly_retention  = optional(string)
     ltr_week_of_year      = optional(number)
+    str_backup_interval   = optional(number)
   }))
   default = {}
 }


### PR DESCRIPTION
Set `short_term_retention_policy` `backup_interval_in_hours` as a variable `str_backup_interval` with default value `12`.
