### PR TITLE
feat: add identity block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,15 @@ resource "azurerm_mssql_server" "this" {
       administrator_login_password
     ]
   }
+
+  dynamic "identity" {
+    for_each = var.mssql_server_identity != null ? [var.mssql_server_identity] : []
+
+    content {
+      type         = identity.value["identity_type"]
+      identity_ids = identity.value["identity_ids"]
+    }
+  }
 }
 
 resource "azurerm_mssql_firewall_rule" "this" {
@@ -102,8 +111,8 @@ resource "azurerm_mssql_server_security_alert_policy" "this" {
 }
 
 resource "azurerm_storage_container" "this" {
-  name                  = var.storage_container_name
-  storage_account_name  = azurerm_storage_account.this.name
+  name                 = var.storage_container_name
+  storage_account_name = azurerm_storage_account.this.name
 }
 
 resource "azurerm_mssql_server_vulnerability_assessment" "this" {

--- a/main.tf
+++ b/main.tf
@@ -76,10 +76,10 @@ resource "azurerm_mssql_server" "this" {
   }
 
   dynamic "identity" {
-    for_each = var.mssql_server_identity != null ? [var.mssql_server_identity] : []
+    for_each = var.identity != null ? [var.identity] : []
 
     content {
-      type         = identity.value["identity_type"]
+      type         = identity.value["type"]
       identity_ids = identity.value["identity_ids"]
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -39,13 +39,26 @@ variable "azuread_authentication_only" {
   default     = false
 }
 
+variable "mssql_server_identity" {
+  description = "The identity to configure for this SQL Server."
+
+  type = object({
+    identity_type = optional(string, "SystemAssigned")
+    identity_ids  = optional(list(string), [])
+  })
+
+  default = null
+}
+
 variable "firewall_rules" {
   description = "A map of identifier => SQL server firewall rule."
+
   type = map(object({
     name             = string
     start_ip_address = string
     end_ip_address   = string
   }))
+
   default = {}
 }
 
@@ -63,6 +76,7 @@ variable "storage_container_name" {
 
 variable "databases" {
   description = "A map of identifier => SQL Database object."
+
   type = map(object({
     name                  = string
     sku_name              = optional(string)
@@ -73,6 +87,7 @@ variable "databases" {
     ltr_week_of_year      = optional(number)
     str_backup_interval   = optional(number)
   }))
+
   default = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -39,11 +39,11 @@ variable "azuread_authentication_only" {
   default     = false
 }
 
-variable "mssql_server_identity" {
+variable "identity" {
   description = "The identity to configure for this SQL Server."
 
   type = object({
-    identity_type = optional(string, "SystemAssigned")
+    type = optional(string, "SystemAssigned")
     identity_ids  = optional(list(string), [])
   })
 


### PR DESCRIPTION
Add identity block to `azurerm_mssql_server`-resource, with identity type set to `SystemAssigned` by default. 