### PR TITLE
feat!: dont ignore changes to database sku

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -17,11 +17,4 @@ resource "azurerm_mssql_database" "this" {
   }
 
   tags = var.tags
-
-  lifecycle {
-    ignore_changes = [
-      # Ignore sku_name to allow sku to be scaled outside of terraform
-      sku_name
-    ]
-  }
 }


### PR DESCRIPTION
It is important that SKU in Terraform config matches SKU in Azure, so that re-running Terraform config creates database with exact same config as before.