### PR TITLE
feat!: use existing Storage account

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -22,6 +22,17 @@ module "log_analytics" {
 
 }
 
+module "storage" {
+  source = "github.com/equinor/terraform-azurerm-storage?ref=v10.3.0"
+
+  account_name                 = "st${random_id.this.hex}"
+  resource_group_name          = azurerm_resource_group.this.name
+  location                     = azurerm_resource_group.this.location
+  log_analytics_workspace_id   = module.log_analytics.workspace_id
+  shared_access_key_enabled    = true
+  network_rules_default_action = "Allow"
+}
+
 module "sql" {
   # source = "github.com/equinor/terraform-azurerm-sql?ref=v0.0.0"
   source = "../.."
@@ -31,7 +42,8 @@ module "sql" {
   location                   = azurerm_resource_group.this.location
   administrator_login        = "masterlogin"
   log_analytics_workspace_id = module.log_analytics.workspace_id
-  storage_account_name       = "st${random_id.this.hex}sql"
+  storage_blob_endpoint      = module.storage.blob_endpoint
+  storage_account_access_key = module.storage.primary_access_key
 }
 
 module "database" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -29,6 +29,17 @@ module "log_analytics" {
   location            = azurerm_resource_group.this.location
 }
 
+module "storage" {
+  source = "github.com/equinor/terraform-azurerm-storage?ref=v10.3.0"
+
+  account_name                 = "st${random_id.this.hex}"
+  resource_group_name          = azurerm_resource_group.this.name
+  location                     = azurerm_resource_group.this.location
+  log_analytics_workspace_id   = module.log_analytics.workspace_id
+  shared_access_key_enabled    = true
+  network_rules_default_action = "Allow"
+}
+
 module "sql" {
   # source = "github.com/equinor/terraform-azurerm-sql?ref=v0.0.0"
   source = "../.."
@@ -38,7 +49,8 @@ module "sql" {
   location                   = azurerm_resource_group.this.location
   administrator_login        = "masterlogin"
   log_analytics_workspace_id = module.log_analytics.workspace_id
-  storage_account_name       = "st${random_id.this.hex}sql"
+  storage_blob_endpoint      = module.storage.blob_endpoint
+  storage_account_access_key = module.storage.primary_access_key
 
   azuread_administrator = {
     login_username = "azureadmasterlogin"

--- a/main.tf
+++ b/main.tf
@@ -100,46 +100,10 @@ resource "azurerm_mssql_server_security_alert_policy" "this" {
   email_account_admins = var.security_alert_policy_email_account_admins
 }
 
-resource "azurerm_storage_account" "this" {
-  name                = var.storage_account_name
-  location            = var.location
-  resource_group_name = var.resource_group_name
-
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  account_kind             = "BlobStorage"
-  access_tier              = "Hot"
-
-  min_tls_version                 = "TLS1_2"
-  enable_https_traffic_only       = true
-  shared_access_key_enabled       = true
-  allow_nested_items_to_be_public = false
-
-  tags = var.tags
-
-  blob_properties {
-    delete_retention_policy {
-      days = 30
-    }
-
-    container_delete_retention_policy {
-      days = 30
-    }
-
-    change_feed_enabled = false
-    versioning_enabled  = false
-  }
-}
-
-resource "azurerm_storage_container" "this" {
-  name                 = var.storage_container_name
-  storage_account_name = azurerm_storage_account.this.name
-}
-
 resource "azurerm_mssql_server_vulnerability_assessment" "this" {
   server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.this.id
-  storage_container_path          = "${azurerm_storage_account.this.primary_blob_endpoint}${azurerm_storage_container.this.name}/"
-  storage_account_access_key      = azurerm_storage_account.this.primary_access_key
+  storage_container_path          = "${var.storage_blob_endpoint}${var.storage_container_name}/"
+  storage_account_access_key      = var.storage_account_access_key
 
   recurring_scans {
     enabled                   = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,13 +18,3 @@ output "administrator_password" {
   value       = azurerm_mssql_server.this.administrator_login_password
   sensitive   = true
 }
-
-output "storage_account_id" {
-  description = "The ID of this Storage Account."
-  value       = azurerm_storage_account.this.id
-}
-
-output "storage_account_name" {
-  description = "The name of this Storage Account."
-  value       = azurerm_storage_account.this.name
-}

--- a/variables.tf
+++ b/variables.tf
@@ -23,9 +23,15 @@ variable "log_analytics_workspace_id" {
   type        = string
 }
 
-variable "storage_account_name" {
-  description = "The name of this Storage account."
+variable "storage_blob_endpoint" {
+  description = "The blob endpoint Storage account to use for this SQL server."
   type        = string
+}
+
+variable "storage_account_access_key" {
+  description = "The shared access key of the Storage account to use for this SQL server."
+  type        = string
+  sensitive   = true
 }
 
 variable "azuread_administrator" {


### PR DESCRIPTION
Storage account should be explicitly created outside of the SQL module, preferably using the Storage module to use its full feature set.

BREAKING CHANGE: remove resources `azurerm_storage_account.this` and `azurerm_storage_container.this`, remove variable `storage_account_name` and add variables `storage_blob_endpoint` and `storage_account_key`.

Fixes #75