### PR TITLE
fix: disable local admin config when using AD auth

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -47,14 +47,15 @@ module "sql" {
   server_name                = "sql-${random_id.this.hex}"
   resource_group_name        = azurerm_resource_group.this.name
   location                   = azurerm_resource_group.this.location
-  administrator_login        = "masterlogin"
+  administrator_login        = null
   log_analytics_workspace_id = module.log_analytics.workspace_id
   storage_blob_endpoint      = module.storage.blob_endpoint
   storage_account_access_key = module.storage.primary_access_key
 
   azuread_administrator = {
-    login_username = "azureadmasterlogin"
-    object_id      = data.azurerm_client_config.current.object_id
+    login_username              = "azureadmasterlogin"
+    object_id                   = data.azurerm_client_config.current.object_id
+    azuread_authentication_only = true
   }
 
   firewall_rules = {

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+locals {
+  azuread_authentication_only = var.azuread_administrator != null ? var.azuread_administrator["azuread_authentication_only"] : false
+}
+
 resource "random_password" "this" {
   length      = 128
   lower       = true
@@ -15,8 +19,8 @@ resource "azurerm_mssql_server" "this" {
   location                     = var.location
   resource_group_name          = var.resource_group_name
   version                      = "12.0"
-  administrator_login          = var.administrator_login
-  administrator_login_password = random_password.this.result
+  administrator_login          = local.azuread_authentication_only ? null : var.administrator_login
+  administrator_login_password = local.azuread_authentication_only ? null : random_password.this.result
   minimum_tls_version          = "1.2"
 
   tags = var.tags
@@ -109,7 +113,7 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
   metric {
     category = "InstanceAndAppAdvanced"
     enabled  = false
-    
+
     retention_policy {
       enabled = false
       days    = 0


### PR DESCRIPTION
Fixes issue where module would throw an error when trying to use AD auth only, because it would still try to configure the local admin even though it's not supported in this scenario.

Updated complete example to test for this.