### PR TITLE
revert: allow custom retention days for extended auditing policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,6 @@ resource "azurerm_mssql_failover_group" "this" {
 resource "azurerm_mssql_server_extended_auditing_policy" "this" {
   server_id              = azurerm_mssql_server.this.id
   log_monitoring_enabled = true
-  retention_in_days      = var.extended_auditing_policy_retention_in_days
 }
 
 # Create diagnostic setting for master database to enable server wide.

--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,13 @@ resource "azurerm_mssql_failover_group" "this" {
 resource "azurerm_mssql_server_extended_auditing_policy" "this" {
   server_id              = azurerm_mssql_server.this.id
   log_monitoring_enabled = true
+
+  # The following arguments are irrelevant when log_monitoring_enabled = true:
+  storage_endpoint                        = null
+  storage_account_access_key              = null
+  storage_account_access_key_is_secondary = null
+  storage_account_subscription_id         = null
+  retention_in_days                       = null
 }
 
 # Create diagnostic setting for master database to enable server wide.

--- a/variables.tf
+++ b/variables.tf
@@ -97,12 +97,6 @@ variable "failover_groups" {
   default = {}
 }
 
-variable "extended_auditing_policy_retention_in_days" {
-  description = "The number of days to retain logs in the Storage Account for this SQL server."
-  type        = number
-  default     = 0
-}
-
 variable "diagnostic_setting_name" {
   description = "The name of this diagnostic setting."
   type        = string


### PR DESCRIPTION
Refs. [`076fd59`](https://github.com/equinor/terraform-azurerm-sql/commit/076fd59dcdb560a3b100a85329f332464a00ab26)

Reverting this feature, due to argument regarding logging to storage account being unnecessary when `log_analytics_enabled = true`.