### PR TITLE
feat!: use RBAC for connecting to Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@
 [![Equinor Terraform Baseline](https://img.shields.io/badge/Equinor%20Terraform%20Baseline-1.0.0-blueviolet)](https://github.com/equinor/terraform-baseline)
 
 Terraform module which creates Azure SQL resources.
+
+## Features
+
+- Creates an Azure SQL server in the provided resource group.
+- Stores vulnerability assessments in the provided Storage account.
+
+## Prerequisites
+
+- Azure role `Contributor` at the resource group scope.
+- Azure rule `Owner` at the Storage account scope.

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -42,8 +42,8 @@ module "sql" {
   location                   = azurerm_resource_group.this.location
   administrator_login        = "masterlogin"
   log_analytics_workspace_id = module.log_analytics.workspace_id
-  storage_blob_endpoint      = module.storage.blob_endpoint
   storage_account_id         = module.storage.account_id
+  storage_blob_endpoint      = module.storage.blob_endpoint
 }
 
 module "database" {

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,4 +1,6 @@
 provider "azurerm" {
+  storage_use_azuread = true
+
   features {}
 }
 
@@ -23,14 +25,12 @@ module "log_analytics" {
 }
 
 module "storage" {
-  source = "github.com/equinor/terraform-azurerm-storage?ref=v10.3.0"
+  source = "github.com/equinor/terraform-azurerm-storage?ref=v11.0.0"
 
-  account_name                 = "st${random_id.this.hex}"
-  resource_group_name          = azurerm_resource_group.this.name
-  location                     = azurerm_resource_group.this.location
-  log_analytics_workspace_id   = module.log_analytics.workspace_id
-  shared_access_key_enabled    = true
-  network_rules_default_action = "Allow"
+  account_name               = "st${random_id.this.hex}"
+  resource_group_name        = azurerm_resource_group.this.name
+  location                   = azurerm_resource_group.this.location
+  log_analytics_workspace_id = module.log_analytics.workspace_id
 }
 
 module "sql" {
@@ -43,7 +43,7 @@ module "sql" {
   administrator_login        = "masterlogin"
   log_analytics_workspace_id = module.log_analytics.workspace_id
   storage_blob_endpoint      = module.storage.blob_endpoint
-  storage_account_access_key = module.storage.primary_access_key
+  storage_account_id         = module.storage.account_id
 }
 
 module "database" {

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -21,7 +21,6 @@ module "log_analytics" {
   workspace_name      = "log-${random_id.this.hex}"
   resource_group_name = azurerm_resource_group.this.name
   location            = azurerm_resource_group.this.location
-
 }
 
 module "storage" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,4 +1,6 @@
 provider "azurerm" {
+  storage_use_azuread = true
+
   features {}
 }
 
@@ -32,12 +34,10 @@ module "log_analytics" {
 module "storage" {
   source = "github.com/equinor/terraform-azurerm-storage?ref=v10.3.0"
 
-  account_name                 = "st${random_id.this.hex}"
-  resource_group_name          = azurerm_resource_group.this.name
-  location                     = azurerm_resource_group.this.location
-  log_analytics_workspace_id   = module.log_analytics.workspace_id
-  shared_access_key_enabled    = true
-  network_rules_default_action = "Allow"
+  account_name               = "st${random_id.this.hex}"
+  resource_group_name        = azurerm_resource_group.this.name
+  location                   = azurerm_resource_group.this.location
+  log_analytics_workspace_id = module.log_analytics.workspace_id
 }
 
 module "sql" {
@@ -49,8 +49,8 @@ module "sql" {
   location                   = azurerm_resource_group.this.location
   administrator_login        = null
   log_analytics_workspace_id = module.log_analytics.workspace_id
+  storage_account_id         = module.storage.account_id
   storage_blob_endpoint      = module.storage.blob_endpoint
-  storage_account_access_key = module.storage.primary_access_key
 
   azuread_administrator = {
     login_username              = "azureadmasterlogin"

--- a/examples/failover-group/main.tf
+++ b/examples/failover-group/main.tf
@@ -1,4 +1,6 @@
 provider "azurerm" {
+  storage_use_azuread = true
+
   features {}
 }
 
@@ -22,12 +24,10 @@ module "log_analytics" {
 module "storage" {
   source = "github.com/equinor/terraform-azurerm-storage?ref=v10.3.0"
 
-  account_name                 = "st${random_id.this.hex}"
-  resource_group_name          = azurerm_resource_group.this.name
-  location                     = azurerm_resource_group.this.location
-  log_analytics_workspace_id   = module.log_analytics.workspace_id
-  shared_access_key_enabled    = true
-  network_rules_default_action = "Allow"
+  account_name               = "st${random_id.this.hex}"
+  resource_group_name        = azurerm_resource_group.this.name
+  location                   = azurerm_resource_group.this.location
+  log_analytics_workspace_id = module.log_analytics.workspace_id
 }
 
 module "sql_primary" {
@@ -39,8 +39,8 @@ module "sql_primary" {
   location                   = azurerm_resource_group.this.location
   administrator_login        = "masterlogin"
   log_analytics_workspace_id = module.log_analytics.workspace_id
+  storage_account_id         = module.storage.account_id
   storage_blob_endpoint      = module.storage.blob_endpoint
-  storage_account_access_key = module.storage.primary_access_key
 
   failover_groups = {
     "main" = {

--- a/examples/failover-group/main.tf
+++ b/examples/failover-group/main.tf
@@ -60,8 +60,8 @@ module "sql_secondary" {
   location                   = var.location_secondary
   administrator_login        = "masterlogin"
   log_analytics_workspace_id = module.log_analytics.workspace_id
+  storage_account_id         = module.storage.account_id
   storage_blob_endpoint      = module.storage.blob_endpoint
-  storage_account_access_key = module.storage.primary_access_key
 }
 
 module "database" {

--- a/main.tf
+++ b/main.tf
@@ -42,18 +42,9 @@ resource "azurerm_mssql_server" "this" {
     ]
   }
 
-  # dynamic "identity" {
-  #   for_each = var.identity != null ? [var.identity] : []
-
-  #   content {
-  #     type         = identity.value["type"]
-  #     identity_ids = identity.value["identity_ids"]
-  #   }
-  # }
-
   identity {
-    type         = "SystemAssigned"
-    identity_ids = []
+    type         = length(var.identity_ids) > 0 ? "SystemAssigned, UserAssigned" : "SystemAssigned"
+    identity_ids = var.identity_ids
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -42,13 +42,18 @@ resource "azurerm_mssql_server" "this" {
     ]
   }
 
-  dynamic "identity" {
-    for_each = var.identity != null ? [var.identity] : []
+  # dynamic "identity" {
+  #   for_each = var.identity != null ? [var.identity] : []
 
-    content {
-      type         = identity.value["type"]
-      identity_ids = identity.value["identity_ids"]
-    }
+  #   content {
+  #     type         = identity.value["type"]
+  #     identity_ids = identity.value["identity_ids"]
+  #   }
+  # }
+
+  identity {
+    type         = "SystemAssigned"
+    identity_ids = []
   }
 }
 
@@ -153,14 +158,21 @@ resource "azurerm_mssql_server_security_alert_policy" "this" {
   email_addresses      = var.security_alert_policy_email_addresses
 }
 
+resource "azurerm_role_assignment" "this" {
+  scope                = var.storage_account_id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_mssql_server.this.identity[0].principal_id
+}
+
 resource "azurerm_mssql_server_vulnerability_assessment" "this" {
   server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.this.id
   storage_container_path          = "${var.storage_blob_endpoint}${var.storage_container_name}/"
-  storage_account_access_key      = var.storage_account_access_key
 
   recurring_scans {
     enabled                   = var.vulnerability_assessment_recurring_scans_enabled
     email_subscription_admins = var.vulnerability_assessment_recurring_scans_email_subscription_admins
     emails                    = var.vulnerability_assessment_recurring_scans_emails
   }
+
+  depends_on = [azurerm_role_assignment.this]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,17 +23,18 @@ variable "log_analytics_workspace_id" {
   type        = string
 }
 
-variable "storage_blob_endpoint" {
-  description = "The blob endpoint Storage account to use for this SQL server."
+variable "storage_account_id" {
+  description = "The ID of the Storage account to use for this SQL server."
   type        = string
 }
 
-variable "storage_account_id" {
-
+variable "storage_blob_endpoint" {
+  description = "The blob endpoint of the Storage account to use for this SQL server."
+  type        = string
 }
 
 variable "storage_container_name" {
-  description = "The name of this Storage Container."
+  description = "The name of the Storage container to use for this SQL server."
   type        = string
   default     = "vulnerability-assessment"
 }
@@ -50,16 +51,11 @@ variable "azuread_administrator" {
   default = null
 }
 
-# variable "identity" {
-#   description = "The identity to configure for this SQL Server."
-
-#   type = object({
-#     type         = optional(string, "SystemAssigned")
-#     identity_ids = optional(list(string), [])
-#   })
-
-#   default = {}
-# }
+variable "identity_ids" {
+  description = "A list of user-assigned identity IDs to be assigned to this SQL server."
+  type        = list(string)
+  default     = []
+}
 
 variable "firewall_rules" {
   description = "A map of firewall rules for this SQL server."

--- a/variables.tf
+++ b/variables.tf
@@ -28,10 +28,8 @@ variable "storage_blob_endpoint" {
   type        = string
 }
 
-variable "storage_account_access_key" {
-  description = "The shared access key of the Storage account to use for this SQL server."
-  type        = string
-  sensitive   = true
+variable "storage_account_id" {
+
 }
 
 variable "storage_container_name" {
@@ -52,16 +50,16 @@ variable "azuread_administrator" {
   default = null
 }
 
-variable "identity" {
-  description = "The identity to configure for this SQL Server."
+# variable "identity" {
+#   description = "The identity to configure for this SQL Server."
 
-  type = object({
-    type         = optional(string, "SystemAssigned")
-    identity_ids = optional(list(string), [])
-  })
+#   type = object({
+#     type         = optional(string, "SystemAssigned")
+#     identity_ids = optional(list(string), [])
+#   })
 
-  default = null
-}
+#   default = {}
+# }
 
 variable "firewall_rules" {
   description = "A map of firewall rules for this SQL server."


### PR DESCRIPTION
Use role-based access control for connecting to Storage account.

Requires Owner role at the Storage account scope.

BREAKING CHANGE: Remove variables `storage_account_access_key` and `identity`. Add variables `storage_account_id` and `identity_ids`.

Fixes #96