### PR TITLE
feat!: force Azure AD admin configuration

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -39,10 +39,14 @@ module "sql" {
   server_name                = "sql-${random_id.this.hex}"
   resource_group_name        = azurerm_resource_group.this.name
   location                   = azurerm_resource_group.this.location
-  administrator_login        = "masterlogin"
   log_analytics_workspace_id = module.log_analytics.workspace_id
   storage_account_id         = module.storage.account_id
   storage_blob_endpoint      = module.storage.blob_endpoint
+
+  azuread_administrator_login_username = "azureadadminlogin"
+  azuread_administrator_object_id      = data.azurerm_client_config.current.object_id
+
+  administrator_login = "sqladminlogin"
 }
 
 module "database" {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -47,16 +47,15 @@ module "sql" {
   server_name                = "sql-${random_id.this.hex}"
   resource_group_name        = azurerm_resource_group.this.name
   location                   = azurerm_resource_group.this.location
-  administrator_login        = null
   log_analytics_workspace_id = module.log_analytics.workspace_id
   storage_account_id         = module.storage.account_id
   storage_blob_endpoint      = module.storage.blob_endpoint
 
-  azuread_administrator = {
-    login_username              = "azureadmasterlogin"
-    object_id                   = data.azurerm_client_config.current.object_id
-    azuread_authentication_only = true
-  }
+  azuread_administrator_login_username = "azureadadminlogin"
+  azuread_administrator_object_id      = data.azurerm_client_config.current.object_id
+  azuread_authentication_only          = false
+
+  administrator_login = "sqladminlogin"
 
   firewall_rules = {
     "azure" = {

--- a/examples/failover-group/main.tf
+++ b/examples/failover-group/main.tf
@@ -4,6 +4,8 @@ provider "azurerm" {
   features {}
 }
 
+data "azurerm_client_config" "current" {}
+
 resource "random_id" "this" {
   byte_length = 8
 }
@@ -37,10 +39,14 @@ module "sql_primary" {
   server_name                = "sql-${random_id.this.hex}-001"
   resource_group_name        = azurerm_resource_group.this.name
   location                   = azurerm_resource_group.this.location
-  administrator_login        = "masterlogin"
   log_analytics_workspace_id = module.log_analytics.workspace_id
   storage_account_id         = module.storage.account_id
   storage_blob_endpoint      = module.storage.blob_endpoint
+
+  azuread_administrator_login_username = "azureadadminlogin"
+  azuread_administrator_object_id      = data.azurerm_client_config.current.object_id
+
+  administrator_login = "sqladminlogin"
 
   failover_groups = {
     "main" = {
@@ -58,10 +64,14 @@ module "sql_secondary" {
   server_name                = "sql-${random_id.this.hex}-002"
   resource_group_name        = azurerm_resource_group.this.name
   location                   = var.location_secondary
-  administrator_login        = "masterlogin"
   log_analytics_workspace_id = module.log_analytics.workspace_id
   storage_account_id         = module.storage.account_id
   storage_blob_endpoint      = module.storage.blob_endpoint
+
+  azuread_administrator_login_username = "azureadadminlogin"
+  azuread_administrator_object_id      = data.azurerm_client_config.current.object_id
+
+  administrator_login = "sqladminlogin"
 }
 
 module "database" {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,3 @@
-locals {
-  azuread_authentication_only = var.azuread_administrator != null ? var.azuread_administrator["azuread_authentication_only"] : false
-}
-
 resource "random_password" "this" {
   length      = 128
   lower       = true
@@ -19,20 +15,16 @@ resource "azurerm_mssql_server" "this" {
   location                     = var.location
   resource_group_name          = var.resource_group_name
   version                      = "12.0"
-  administrator_login          = local.azuread_authentication_only ? null : var.administrator_login
-  administrator_login_password = local.azuread_authentication_only ? null : random_password.this.result
+  administrator_login          = var.azuread_authentication_only ? null : var.administrator_login
+  administrator_login_password = var.azuread_authentication_only ? null : random_password.this.result
   minimum_tls_version          = "1.2"
 
   tags = var.tags
 
-  dynamic "azuread_administrator" {
-    for_each = var.azuread_administrator != null ? [var.azuread_administrator] : []
-
-    content {
-      login_username              = azuread_administrator.value["login_username"]
-      object_id                   = azuread_administrator.value["object_id"]
-      azuread_authentication_only = azuread_administrator.value["azuread_authentication_only"]
-    }
+  azuread_administrator {
+    login_username              = var.azuread_administrator_login_username
+    object_id                   = var.azuread_administrator_object_id
+    azuread_authentication_only = var.azuread_authentication_only
   }
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -39,16 +39,20 @@ variable "storage_container_name" {
   default     = "vulnerability-assessment"
 }
 
-variable "azuread_administrator" {
-  description = "An Azure AD administrator to configure for this SQL server."
+variable "azuread_administrator_login_username" {
+  description = "The login username of the Azure AD administrator for this SQL server."
+  type        = string
+}
 
-  type = object({
-    login_username              = string
-    object_id                   = string
-    azuread_authentication_only = optional(bool, false)
-  })
+variable "azuread_administrator_object_id" {
+  description = "The object ID of the Azure AD administrator for this SQL server."
+  type        = string
+}
 
-  default = null
+variable "azuread_authentication_only" {
+  description = "Should Azure AD authentication only be enabled for this SQL server?"
+  type        = bool
+  default     = false
 }
 
 variable "identity_ids" {


### PR DESCRIPTION
BREAKING CHANGE: remove variable `azuread_administrator`, add variables `azuread_administrator_login_username`, `azuread_administrator_object_id` and `azuread_authentication_only`.

Fixes #95