### PR TITLE
feat!: enable Azure AD auth only by default

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -45,8 +45,6 @@ module "sql" {
 
   azuread_administrator_login_username = "azureadadminlogin"
   azuread_administrator_object_id      = data.azurerm_client_config.current.object_id
-
-  administrator_login = "sqladminlogin"
 }
 
 module "database" {

--- a/examples/failover-group/main.tf
+++ b/examples/failover-group/main.tf
@@ -46,8 +46,6 @@ module "sql_primary" {
   azuread_administrator_login_username = "azureadadminlogin"
   azuread_administrator_object_id      = data.azurerm_client_config.current.object_id
 
-  administrator_login = "sqladminlogin"
-
   failover_groups = {
     "main" = {
       name              = "fog-${random_id.this.hex}"
@@ -70,8 +68,6 @@ module "sql_secondary" {
 
   azuread_administrator_login_username = "azureadadminlogin"
   azuread_administrator_object_id      = data.azurerm_client_config.current.object_id
-
-  administrator_login = "sqladminlogin"
 }
 
 module "database" {

--- a/variables.tf
+++ b/variables.tf
@@ -13,11 +13,6 @@ variable "location" {
   type        = string
 }
 
-variable "administrator_login" {
-  description = "The login username of the administrator of this SQL server."
-  type        = string
-}
-
 variable "log_analytics_workspace_id" {
   description = "The ID of the Log Analytics workspace to send diagnostics to."
   type        = string
@@ -52,7 +47,13 @@ variable "azuread_administrator_object_id" {
 variable "azuread_authentication_only" {
   description = "Should Azure AD authentication only be enabled for this SQL server?"
   type        = bool
-  default     = false
+  default     = true
+}
+
+variable "administrator_login" {
+  description = "The login username of the administrator of this SQL server."
+  type        = string
+  default     = null
 }
 
 variable "identity_ids" {


### PR DESCRIPTION
BREAKING CHANGE: variable `azuread_authentication_only` default value changed from `false` to `true`.

Fixes #98