### PR TITLE
chore: update submodule `database`

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -41,11 +41,3 @@ module "sql" {
   azuread_administrator_login_username = "azureadadminlogin"
   azuread_administrator_object_id      = data.azurerm_client_config.current.object_id
 }
-
-module "database" {
-  source = "../../modules/database"
-
-  database_name              = "sqldb-${random_id.this.hex}"
-  server_id                  = module.sql.server_id
-  log_analytics_workspace_id = module.log_analytics.workspace_id
-}

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -42,7 +42,10 @@ module "sql" {
   azuread_administrator_object_id      = data.azurerm_client_config.current.object_id
 }
 
-resource "azurerm_mssql_database" "example" {
-  name      = "sqldb-${random_id.this.hex}"
-  server_id = module.sql.server_id
+module "database" {
+  source = "../../modules/database"
+
+  database_name              = "sqldb-${random_id.this.hex}"
+  server_id                  = module.sql.server_id
+  log_analytics_workspace_id = module.log_analytics.workspace_id
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -63,11 +63,3 @@ module "sql" {
 
   tags = local.tags
 }
-
-module "database" {
-  source = "../../modules/database"
-
-  database_name              = "sqldb-${random_id.this.hex}"
-  server_id                  = module.sql.server_id
-  log_analytics_workspace_id = module.log_analytics.workspace_id
-}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -64,7 +64,10 @@ module "sql" {
   tags = local.tags
 }
 
-resource "azurerm_mssql_database" "example" {
-  name      = "sqldb-${random_id.this.hex}"
-  server_id = module.sql.server_id
+module "database" {
+  source = "../../modules/database"
+
+  database_name              = "sqldb-${random_id.this.hex}"
+  server_id                  = module.sql.server_id
+  log_analytics_workspace_id = module.log_analytics.workspace_id
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -12,6 +12,7 @@ resource "azurerm_mssql_database" "this" {
   storage_account_type           = var.storage_account_type
 
   tags = var.tags
+
   dynamic "long_term_retention_policy" {
     for_each = var.long_term_retention_policy != null ? [var.long_term_retention_policy] : []
     content {
@@ -21,6 +22,7 @@ resource "azurerm_mssql_database" "this" {
       week_of_year      = long_term_retention_policy.value.week_of_year
     }
   }
+
   threat_detection_policy {
     state                      = var.threat_detection_policy.state
     disabled_alerts            = var.threat_detection_policy.disabled_alerts
@@ -33,6 +35,7 @@ resource "azurerm_mssql_database" "this" {
 
   dynamic "identity" {
     for_each = length(var.identities) > 0 ? ["identity"] : []
+
     content {
       # UserAssigned identity is currently the only supported identity option
       type         = "UserAssigned"

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -34,12 +34,12 @@ resource "azurerm_mssql_database" "this" {
   }
 
   dynamic "identity" {
-    for_each = length(var.identities) > 0 ? ["identity"] : []
+    for_each = length(var.identity_ids) > 0 ? [0] : []
 
     content {
       # UserAssigned identity is currently the only supported identity option
       type         = "UserAssigned"
-      identity_ids = var.identities
+      identity_ids = var.identity_ids
     }
   }
 

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -13,6 +13,11 @@ resource "azurerm_mssql_database" "this" {
 
   tags = var.tags
 
+  short_term_retention_policy {
+    retention_days           = var.short_term_retention_policy_retention_days
+    backup_interval_in_hours = var.short_term_retention_policy_backup_interval_in_hours
+  }
+
   long_term_retention_policy {
     weekly_retention  = var.long_term_retention_policy_weekly_retention
     monthly_retention = var.long_term_retention_policy_monthly_retention

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -72,8 +72,4 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
       category = metric.value
     }
   }
-
-  depends_on = [
-    azurerm_mssql_database.this
-  ]
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_mssql_database" "this" {
   elastic_pool_id                = var.elastic_pool_id
   collation                      = var.collation
   enclave_type                   = var.enclave_type
-  maintenance_configuration_name = var.elastic_pool_id == null ? var.maintenance_configuration_name : null # Conflifcts with elastic pool
+  maintenance_configuration_name = var.elastic_pool_id == null ? var.maintenance_configuration_name : null # Conflicts with elastic pool
   ledger_enabled                 = var.ledger_enabled
   license_type                   = var.license_type
   max_size_gb                    = var.max_size_gb

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_mssql_database" "this" {
   ledger_enabled                 = var.ledger_enabled
   license_type                   = var.license_type
   max_size_gb                    = var.max_size_gb
-  sku_name                       = var.sku_name
+  sku_name                       = var.elastic_pool_id == null ? var.sku_name : "ElasticPool"
   storage_account_type           = var.storage_account_type
 
   tags = var.tags

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -13,14 +13,11 @@ resource "azurerm_mssql_database" "this" {
 
   tags = var.tags
 
-  dynamic "long_term_retention_policy" {
-    for_each = var.long_term_retention_policy != null ? [var.long_term_retention_policy] : []
-    content {
-      weekly_retention  = long_term_retention_policy.value.weekly_retention
-      monthly_retention = long_term_retention_policy.value.monthly_retention
-      yearly_retention  = long_term_retention_policy.value.yearly_retention
-      week_of_year      = long_term_retention_policy.value.week_of_year
-    }
+  long_term_retention_policy {
+    weekly_retention  = var.long_term_retention_policy_weekly_retention
+    monthly_retention = var.long_term_retention_policy_monthly_retention
+    yearly_retention  = var.long_term_retention_policy_yearly_retention
+    week_of_year      = var.long_term_retention_policy_week_of_year
   }
 
   threat_detection_policy {

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -46,7 +46,7 @@ variable "ledger_enabled" {
 variable "license_type" {
   description = "Specifies the license type for this database"
   type        = string
-  default     = null
+  default     = "LicenseIncluded"
 }
 
 variable "max_size_gb" {

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -67,20 +67,28 @@ variable "storage_account_type" {
   default     = "Geo"
 }
 
-variable "long_term_retention_policy" {
-  description = "Sets the long term retention policy rules"
-  type = object({
-    weekly_retention  = optional(string, "P1M")
-    monthly_retention = optional(string, "PT0S")
-    yearly_retention  = optional(string, "PT0S")
-    week_of_year      = optional(number, 1)
-  })
-  default = {
-    weekly_retention  = "P1M"
-    monthly_retention = "PT0S"
-    yearly_retention  = "PT0S"
-    week_of_year      = "1"
-  }
+variable "long_term_retention_policy_weekly_retention" {
+  description = "The duration that weekly long-term backups should be retained. Value must be in an ISO 8601 duration format, e.g. `P1Y`, `P1M`, `P1W` or `P7D`."
+  type        = string
+  default     = "PT0S"
+}
+
+variable "long_term_retention_policy_monthly_retention" {
+  description = "The duration that monthly long-term backups should be retained. Value must be in an ISO 8601 duration format, e.g. `P1Y`, `P1M`, `P4W` or `P30D`."
+  type        = string
+  default     = "PT0S"
+}
+
+variable "long_term_retention_policy_yearly_retention" {
+  description = "The duration that yearly long-term backups should be retained. Value must be in an ISO 8601 duration format, e.g. `P1Y`, `P12M`, `P52W` or `P365D`"
+  type        = string
+  default     = "PT0S"
+}
+
+variable "long_term_retention_policy_week_of_year" {
+  description = "The week of year to take the yearly long-term backup. Value must be between `1` and `52`."
+  type        = number
+  default     = 1
 }
 
 variable "threat_detection_policy" {

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -67,6 +67,18 @@ variable "storage_account_type" {
   default     = "Geo"
 }
 
+variable "short_term_retention_policy_retention_days" {
+  description = "The number of days that point-in-time restore backups should be retained. Value must be between `7` and `35`"
+  type        = number
+  default     = 7
+}
+
+variable "short_term_retention_policy_backup_interval_in_hours" {
+  description = "The hours between each differential backup. Value has to be 12 or 24, defaults to 12 hours."
+  type        = number
+  default     = 12
+}
+
 variable "long_term_retention_policy_weekly_retention" {
   description = "The duration that weekly long-term backups should be retained. Value must be in an ISO 8601 duration format, e.g. `P1Y`, `P1M`, `P1W` or `P7D`."
   type        = string

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -134,6 +134,8 @@ variable "diagnostic_setting_enabled_log_categories" {
   description = "A list of log categories to be enabled for this diagnostic setting."
   type        = list(string)
 
+  # Enable service logs by default.
+  # Ref: https://learn.microsoft.com/en-us/azure/azure-sql/database/metrics-diagnostic-telemetry-logging-streaming-export-configure?view=azuresql&tabs=azure-portal#databases-in-azure-sql-database
   default = [
     "AutomaticTuning",
     "Blocks",

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -133,6 +133,7 @@ variable "diagnostic_setting_name" {
 variable "diagnostic_setting_enabled_log_categories" {
   description = "A list of log categories to be enabled for this diagnostic setting."
   type        = list(string)
+
   default = [
     "AutomaticTuning",
     "Blocks",
@@ -147,13 +148,9 @@ variable "diagnostic_setting_enabled_log_categories" {
 }
 
 variable "diagnostic_setting_enabled_metric_categories" {
-  description = "A list of log categories to be enabled for this diagnostic setting."
+  description = "A list of metric categories to be enabled for this diagnostic setting."
   type        = list(string)
-  default = [
-    "Basic",
-    "InstanceAndAppAdvanced",
-    "WorkloadManagement"
-  ]
+  default     = []
 }
 
 variable "tags" {

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -98,7 +98,7 @@ variable "threat_detection_policy" {
   default = {}
 }
 
-variable "identities" {
+variable "identity_ids" {
   description = "List of user assigned identities to be configured on this database"
   type        = list(string)
   default     = []

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -46,7 +46,7 @@ variable "ledger_enabled" {
 variable "license_type" {
   description = "Specifies the license type for this database"
   type        = string
-  default     = "LicenseIncluded"
+  default     = null
 }
 
 variable "max_size_gb" {

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -58,7 +58,7 @@ variable "max_size_gb" {
 variable "sku_name" {
   description = "Specifies the SKU to use for this database"
   type        = string
-  default     = null
+  default     = "Basic"
 }
 
 variable "storage_account_type" {

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -127,7 +127,7 @@ variable "identity_ids" {
 variable "diagnostic_setting_name" {
   description = "The name of this diagnostic setting."
   type        = string
-  default     = "audit-logs"
+  default     = "service-logs"
 }
 
 variable "diagnostic_setting_enabled_log_categories" {

--- a/modules/database/versions.tf
+++ b/modules/database/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.84.0"
+    }
+  }
+}

--- a/modules/database/versions.tf
+++ b/modules/database/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.84.0"
+      version = ">= 3.87.0"
     }
   }
 }


### PR DESCRIPTION
- Remove `azurerm_mssql_database` from examples to prevent promotion of using that resource directly. Would be optimal to use this submodule instead, however we're currently unable to do so due to our use of the `lifecycle.prevent_destroy` meta-argument which prevents Terratest from doing its thing.
- Split LTR config into multiple variables.
- Add STR config.
- Set Basic SKU by default.
- Don't set license type by default.
- Disable metric categories by default for diagnostic setting.