### PR TITLE
fix(database): disabled metric categories not configured

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -73,9 +73,12 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     for_each = toset(concat(local.diagnostic_setting_metric_categories, var.diagnostic_setting_enabled_metric_categories))
 
     content {
+      # Azure expects explicit configuration of both enabled and disabled metric categories.
       category = metric.value
       enabled  = contains(var.diagnostic_setting_enabled_metric_categories, metric.value)
 
+      # The "retention_policy" block is deprecated, however while not configured by Terraform, it'll still be configured by Azure.
+      # Configure block to prevent conflict between Terraform and Azure until this issue has been resolved upstream in the Azure provider.
       retention_policy {
         enabled = false
         days    = 0

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -75,6 +75,11 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
     content {
       category = metric.value
       enabled  = contains(var.diagnostic_setting_enabled_metric_categories, metric.value)
+
+      retention_policy {
+        enabled = false
+        days    = 0
+      }
     }
   }
 }

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -1,5 +1,5 @@
 locals {
-  diagnostic_setting_metric_categories = ["Basic", "InstanceAppAdvanced", "WorkloadManagement"]
+  diagnostic_setting_metric_categories = ["Basic", "InstanceAndAppAdvanced", "WorkloadManagement"]
 }
 
 resource "azurerm_mssql_database" "this" {

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -1,3 +1,7 @@
+locals {
+  diagnostic_setting_metric_categories = ["Basic", "InstanceAppAdvanced", "WorkloadManagement"]
+}
+
 resource "azurerm_mssql_database" "this" {
   name                           = var.database_name
   server_id                      = var.server_id
@@ -66,10 +70,11 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
   }
 
   dynamic "metric" {
-    for_each = toset(var.diagnostic_setting_enabled_metric_categories)
+    for_each = toset(concat(local.diagnostic_setting_metric_categories, var.diagnostic_setting_enabled_metric_categories))
 
     content {
       category = metric.value
+      enabled  = contains(var.diagnostic_setting_enabled_metric_categories, metric.value)
     }
   }
 }


### PR DESCRIPTION
Azure expects explicit configuration of both enabled and disabled metric categories.

Configure disabled metric categories to prevent conflict between Terraform and Azure.