### PR TITLE
refactor(database)!: rename variables

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -18,15 +18,15 @@ resource "azurerm_mssql_database" "this" {
   tags = var.tags
 
   short_term_retention_policy {
-    retention_days           = var.short_term_retention_policy_retention_days
-    backup_interval_in_hours = var.short_term_retention_policy_backup_interval_in_hours
+    retention_days           = var.str_policy_retention_days
+    backup_interval_in_hours = var.str_policy_backup_interval_in_hours
   }
 
   long_term_retention_policy {
-    weekly_retention  = var.long_term_retention_policy_weekly_retention
-    monthly_retention = var.long_term_retention_policy_monthly_retention
-    yearly_retention  = var.long_term_retention_policy_yearly_retention
-    week_of_year      = var.long_term_retention_policy_week_of_year
+    weekly_retention  = var.ltr_policy_weekly_retention
+    monthly_retention = var.ltr_policy_monthly_retention
+    yearly_retention  = var.ltr_policy_yearly_retention
+    week_of_year      = var.ltr_policy_week_of_year
   }
 
   # Might be irrelevant when threat detection is configured at the server level.

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -19,7 +19,7 @@ resource "azurerm_mssql_database" "this" {
 
   short_term_retention_policy {
     retention_days           = var.str_policy_retention_days
-    backup_interval_in_hours = var.str_policy_backup_interval_in_hours
+    backup_interval_in_hours = var.str_policy_interval_hours
   }
 
   long_term_retention_policy {

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -73,7 +73,7 @@ variable "str_policy_retention_days" {
   default     = 7
 }
 
-variable "str_policy_backup_interval_in_hours" {
+variable "str_policy_interval_hours" {
   description = "The hours between each differential backup. Value has to be 12 or 24, defaults to 12 hours."
   type        = number
   default     = 12

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -67,37 +67,37 @@ variable "storage_account_type" {
   default     = "Geo"
 }
 
-variable "short_term_retention_policy_retention_days" {
+variable "str_policy_retention_days" {
   description = "The number of days that point-in-time restore backups should be retained. Value must be between `7` and `35`"
   type        = number
   default     = 7
 }
 
-variable "short_term_retention_policy_backup_interval_in_hours" {
+variable "str_policy_backup_interval_in_hours" {
   description = "The hours between each differential backup. Value has to be 12 or 24, defaults to 12 hours."
   type        = number
   default     = 12
 }
 
-variable "long_term_retention_policy_weekly_retention" {
+variable "ltr_policy_weekly_retention" {
   description = "The duration that weekly long-term backups should be retained. Value must be in an ISO 8601 duration format, e.g. `P1Y`, `P1M`, `P1W` or `P7D`."
   type        = string
   default     = "PT0S"
 }
 
-variable "long_term_retention_policy_monthly_retention" {
+variable "ltr_policy_monthly_retention" {
   description = "The duration that monthly long-term backups should be retained. Value must be in an ISO 8601 duration format, e.g. `P1Y`, `P1M`, `P4W` or `P30D`."
   type        = string
   default     = "PT0S"
 }
 
-variable "long_term_retention_policy_yearly_retention" {
+variable "ltr_policy_yearly_retention" {
   description = "The duration that yearly long-term backups should be retained. Value must be in an ISO 8601 duration format, e.g. `P1Y`, `P12M`, `P52W` or `P365D`"
   type        = string
   default     = "PT0S"
 }
 
-variable "long_term_retention_policy_week_of_year" {
+variable "ltr_policy_week_of_year" {
   description = "The week of year to take the yearly long-term backup. Value must be between `1` and `52`."
   type        = number
   default     = 1


### PR DESCRIPTION
Keep length of variables names under or equals to 30 characters.