### PR TITLE
fix: disallow null input value

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -37,11 +37,13 @@ variable "storage_container_name" {
 variable "azuread_administrator_login_username" {
   description = "The login username of the Azure AD administrator for this SQL server."
   type        = string
+  nullable    = false
 }
 
 variable "azuread_administrator_object_id" {
   description = "The object ID of the Azure AD administrator for this SQL server."
   type        = string
+  nullable    = false
 }
 
 variable "azuread_authentication_only" {


### PR DESCRIPTION
Disallow null input value by adding `nullable` argument to variables `azuread_administrator_login_username` and `azuread_administrator_object_id`, to catch errors related to these earlier in deployment process.

Ref.: https://developer.hashicorp.com/terraform/language/values/variables#disallowing-null-input-values