### PR TITLE
fix(database): remove deprecated argument `retention_policy` for resource `azurerm_monitor_diagnostic_setting`

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -76,13 +76,6 @@ resource "azurerm_monitor_diagnostic_setting" "this" {
       # Azure expects explicit configuration of both enabled and disabled metric categories.
       category = metric.value
       enabled  = contains(var.diagnostic_setting_enabled_metric_categories, metric.value)
-
-      # The "retention_policy" block is deprecated, however while not configured by Terraform, it'll still be configured by Azure.
-      # Configure block to prevent conflict between Terraform and Azure until this issue has been resolved upstream in the Azure provider.
-      retention_policy {
-        enabled = false
-        days    = 0
-      }
     }
   }
 }


### PR DESCRIPTION
Azure and Azure provider no longer implicitly add this argument if not set in Terraform, so we can remove it.

Here's the warning:

![image](https://github.com/equinor/terraform-azurerm-sql/assets/46495473/56e7ff77-16ea-44ab-b9f5-d45aa2725478)