### PR TITLE
feat: output fully qualified domain name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,11 @@ output "server_name" {
   value       = azurerm_mssql_server.this.name
 }
 
+output "server_fqdn" {
+  description = "The fully qualified domain name (FQDN) of this SQL server."
+  value       = azurerm_mssql_server.this.fully_qualified_domain_name
+}
+
 output "administrator_login" {
   description = "The login username of the administrator for this SQL server."
   value       = azurerm_mssql_server.this.administrator_login


### PR DESCRIPTION
Allows us to get the FQDN directly from the module output, instead of manually constructing it as follows: `"${module.sql.server_name}.database.windows.net"`.