### PR TITLE
fix: prevent replacement of role assignment for any update to server

### DIFF
--- a/docs/import.md
+++ b/docs/import.md
@@ -1,0 +1,13 @@
+# Import
+
+This document contains instructions for [importing existing resources](https://developer.hashicorp.com/terraform/cli/import) to be managed by this module.
+
+## SQL server
+
+The system-assigned identity **must** be enabled for the existing SQL server before importing. This is required for this module to configure Microsoft Entra authentication from the SQL server to the given Storage account.
+
+Enable the system-assigned identity for the existing SQL server by running the following Azure CLI command:
+
+```console
+az sql server update -n <SERVER_NAME> -g <RESOURCE_GROUP_NAME> --identity-type SystemAssigned
+```

--- a/main.tf
+++ b/main.tf
@@ -107,19 +107,10 @@ resource "azurerm_mssql_server_security_alert_policy" "this" {
   email_addresses      = var.security_alert_policy_email_addresses
 }
 
-data "azurerm_mssql_server" "this" {
-  name                = azurerm_mssql_server.this.name
-  resource_group_name = azurerm_mssql_server.this.resource_group_name
-}
-
 resource "azurerm_role_assignment" "this" {
   scope                = var.storage_account_id
   role_definition_name = "Storage Blob Data Contributor"
-  principal_id         = data.azurerm_mssql_server.this.identity[0].principal_id
-  # This resource sometimes throws the following error: The argument "principal_id" is required, but no definition was found.
-  # To fix this issue, get "principal_id" from a data source to read its value during the the apply phase instead of the plan phase.
-  # This ensures the SQL server system-assigned identity is always enabled before trying to read its principal ID.
-  # Ref: https://developer.hashicorp.com/terraform/language/data-sources#data-resource-behavior
+  principal_id         = azurerm_mssql_server.this.identity[0].principal_id
 }
 
 resource "azurerm_mssql_server_vulnerability_assessment" "this" {


### PR DESCRIPTION
Reading the principal ID of the SQL server system-assigned identity from a data source causes the role assignment to be replaced (destroyed then re-created) for any update to the SQL server. Prevent this behavior by reading the principal ID from the SQL server resource itself.

The error described in the removed comment only occurs when trying to import an existing SQL server without a system-assigned identity into this module. This error can be fixed by enabling the system-assigned identity outside of Terraform before attempting to import the SQL server. Add a document containing import instructions instead.