### PR TITLE
fix(database)!: license type should be managed by owner of existing license

### DIFF
--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -10,10 +10,12 @@ resource "azurerm_mssql_database" "this" {
   enclave_type                   = var.enclave_type
   maintenance_configuration_name = var.elastic_pool_id == null ? var.maintenance_configuration_name : null # Conflicts with elastic pool
   ledger_enabled                 = var.ledger_enabled
-  license_type                   = var.license_type
   max_size_gb                    = var.max_size_gb
   sku_name                       = var.elastic_pool_id == null ? var.sku_name : "ElasticPool"
   storage_account_type           = var.storage_account_type
+
+  # Should be managed by owner of existing license, usually platform team.
+  license_type = null
 
   tags = var.tags
 
@@ -52,8 +54,12 @@ resource "azurerm_mssql_database" "this" {
   lifecycle {
     # Protect database from accidental deletion
     prevent_destroy = true
-  }
 
+    ignore_changes = [
+      # Should be managed by owner of existing license, usually platform team.
+      license_type
+    ]
+  }
 }
 
 resource "azurerm_monitor_diagnostic_setting" "this" {

--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -43,12 +43,6 @@ variable "ledger_enabled" {
   default     = false
 }
 
-variable "license_type" {
-  description = "Specifies a license type for this SQL database."
-  type        = string
-  default     = null
-}
-
 variable "max_size_gb" {
   description = "Sets a maximum possible size for this SQL database."
   type        = number


### PR DESCRIPTION
Setting license type to `LicenseIncluded` would apply an existing license to this SQL database and enable the Azure Hybrid Benefit discount. This should only be configured by the owner of the existing license, e.g. the platform team.

Fixes a potential error where configuration done by this module would conflict with configuration by owner of existing license.