### PR TITLE
fix(database): incorrect default value for variables `min_capacity` and `auto_pause_delay_in_minutes`

### DIFF
--- a/modules/database/variables.tf
+++ b/modules/database/variables.tf
@@ -141,13 +141,13 @@ variable "tags" {
 }
 
 variable "min_capacity" {
-  description = "Minimal capacity that this SQL database will always have allocated if not paused. Value must be greater than 0 if using a SKU in the serverless compute tier."
+  description = "Minimal capacity that this SQL database will always have allocated if not paused. Required if using a SKU in the serverless compute tier."
   type        = number
-  default     = 0
+  default     = null
 }
 
 variable "auto_pause_delay_in_minutes" {
-  description = "Time in minutes after which this SQL database is automatically paused. Value must be greater than 0 if using a SKU in the serverless compute tier."
+  description = "Time in minutes after which this SQL database is automatically paused. Required if using a SKU in the serverless compute tier."
   type        = number
-  default     = 0
+  default     = null
 }


### PR DESCRIPTION
Azure provider v4.24 added additional validation for the `auto_pause_delay_in_minutes` argument that causes this module to throw an error by default (hashicorp/terraform-provider-azurerm#28670).

Fix this error by setting default values to `null` instead of `0`, which corresponds to the default values configured by Azure when using a non-serverless SKU.