### PR TITLE
fix: identical names for separate `azurerm_monitor_diagnostic_setting` resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "azurerm_mssql_server_extended_auditing_policy" "this" {
 }
 
 # Create diagnostic setting for master database to enable server wide.
-resource "azurerm_monitor_diagnostic_setting" "this" {
+resource "azurerm_monitor_diagnostic_setting" "server" {
   name                       = var.diagnostic_setting_name
   target_resource_id         = "${azurerm_mssql_server.this.id}/databases/master"
   log_analytics_workspace_id = var.log_analytics_workspace_id

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -64,7 +64,7 @@ resource "azurerm_mssql_database" "this" {
   }
 }
 
-resource "azurerm_monitor_diagnostic_setting" "this" {
+resource "azurerm_monitor_diagnostic_setting" "database" {
   name                       = var.diagnostic_setting_name
   target_resource_id         = azurerm_mssql_database.this.id
   log_analytics_workspace_id = var.log_analytics_workspace_id

--- a/modules/database/moved.tf
+++ b/modules/database/moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = azurerm_monitor_diagnostic_setting.this
+  to   = azurerm_monitor_diagnostic_setting.database
+}

--- a/moved.tf
+++ b/moved.tf
@@ -1,0 +1,4 @@
+moved {
+  from = azurerm_monitor_diagnostic_setting.this
+  to   = azurerm_monitor_diagnostic_setting.server
+}


### PR DESCRIPTION
Currently, both the main module and the `database` submodule create a resource named `azurerm_monitor_diagnostic_setting.this`.

This looks confusing on the Terraform Registry page for this module, as it looks like this module creates the same resource twice.

Rename the `azurerm_monitor_diagnostic_setting.this` resource in the main module to `azurerm_monitor_diagnostic_setting.server` to reflect that this diagnostic setting is scoped to the SQL server.

Rename the `azurerm_monitor_diagnostic_setting.this` resource in the `database` submodule to `azurerm_monitor_diagnostic_setting.database` to reflect that this diagnostic setting is scoped to the SQL database.