### PR TITLE
feat: add missing "required" arguments

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -11,7 +11,8 @@ resource "random_id" "this" {
 }
 
 module "log_analytics" {
-  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.5.0"
+  source  = "equinor/log-analytics/azurerm"
+  version = "2.4.1"
 
   workspace_name      = "log-${random_id.this.hex}"
   resource_group_name = var.resource_group_name
@@ -19,7 +20,8 @@ module "log_analytics" {
 }
 
 module "storage" {
-  source = "github.com/equinor/terraform-azurerm-storage?ref=v11.0.0"
+  source  = "equinor/storage/azurerm"
+  version = "12.13.0"
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name
@@ -28,7 +30,8 @@ module "storage" {
 }
 
 module "sql" {
-  # source = "github.com/equinor/terraform-azurerm-sql?ref=v0.0.0"
+  # source  = "equinor/sql/azurerm"
+  # version = "0.0.0"
   source = "../.."
 
   server_name                = "sql-${random_id.this.hex}"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -17,7 +17,8 @@ resource "random_id" "this" {
 }
 
 module "log_analytics" {
-  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.5.0"
+  source  = "equinor/log-analytics/azurerm"
+  version = "2.4.1"
 
   workspace_name      = "log-${random_id.this.hex}"
   resource_group_name = var.resource_group_name
@@ -25,7 +26,8 @@ module "log_analytics" {
 }
 
 module "storage" {
-  source = "github.com/equinor/terraform-azurerm-storage?ref=v10.3.0"
+  source  = "equinor/storage/azurerm"
+  version = "12.13.0"
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name
@@ -34,7 +36,8 @@ module "storage" {
 }
 
 module "sql" {
-  # source = "github.com/equinor/terraform-azurerm-sql?ref=v0.0.0"
+  # source  = "equinor/sql/azurerm"
+  # version = "0.0.0"
   source = "../.."
 
   server_name                = "sql-${random_id.this.hex}"

--- a/main.tf
+++ b/main.tf
@@ -116,6 +116,8 @@ resource "azurerm_role_assignment" "this" {
 resource "azurerm_mssql_server_vulnerability_assessment" "this" {
   server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.this.id
   storage_container_path          = "${coalesce(var.storage_blob_endpoint, local.storage_blob_endpoint)}${var.storage_container_name}/"
+  storage_account_access_key      = var.storage_access_key
+  storage_container_sas_key       = var.storage_container_sas_key
 
   recurring_scans {
     enabled                   = var.vulnerability_assessment_recurring_scans_enabled

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,18 @@ variable "storage_container_name" {
   default     = "vulnerability-assessment"
 }
 
+variable "storage_access_key" {
+  description = "The primary access key of the blob storage endpoint."
+  type        = string
+  default     = null
+}
+
+variable "storage_container_sas_key" {
+  description = "Specifies the shared access signature (SAS Key) that has write access to the blob container specified in storage_container_path property."
+  type        = string
+  default     = null
+}
+
 variable "azuread_administrator_login_username" {
   description = "The login username of the Microsoft Entra administrator for this SQL server."
   type        = string


### PR DESCRIPTION
With the newest provider version, the following error message is given:

![bilde](https://github.com/user-attachments/assets/3427c022-4406-4107-bb60-11c570201379)

The arguments `storage_account_access_key` and `storage_container_sas_key` are each optional, but if either is not defined the other is required. Therefore I've added them both as variables with the default set as null. 

The addition of these variables only fixes the issue for storage accounts that are not behind firewalls or vNets though, as the arguments can only be set in those scenarios. For storage accounts that are behind firewalls and/or vNets, they should roll back to provider version 4.30.