### PR TITLE
docs: add admin password complexity rationale

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,5 @@
+# Generate random password based on Azure SQL password policy.
+# Ref: https://learn.microsoft.com/en-us/sql/relational-databases/security/password-policy
 resource "random_password" "this" {
   length      = 128
   lower       = true


### PR DESCRIPTION
Add comment containing a link to the Azure SQL password policy documentation, as this document was used as a reference for how complex the admin password should be.