### PR TITLE
fix: exclude broken Azure provider version v4.31

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 4.0.0"
+      version = ">= 4.0.0, != 4.31.0"
     }
 
     random = {


### PR DESCRIPTION
With the newest `azurerm` provider version `v4.31.0`, the following error message is given when running `terraform plan`:

![bilde](https://github.com/user-attachments/assets/3427c022-4406-4107-bb60-11c570201379)

The error message relates to the resource `azurerm_mssql_server_vulnerability_assessment` and arguments `storage_account_access_key` and `storage_container_sas_key`. The arguments are each optional, but if either is not defined the other is required. As we currently use role assignments to authenticate to the storage account, we should not need to roll back to using keys.

Until a fix has been done in the `azurerm` provider, we'll exclude the broken provider version.