### PR TITLE
docs: clarify authentication to Storage account

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,6 +119,11 @@ resource "azurerm_mssql_server_vulnerability_assessment" "this" {
   server_security_alert_policy_id = azurerm_mssql_server_security_alert_policy.this.id
   storage_container_path          = "${coalesce(var.storage_blob_endpoint, local.storage_blob_endpoint)}${var.storage_container_name}/"
 
+  # The following arguments are irrelevant when creating resource "azurerm_role_assignment.this".
+  # This role assignment allows the SQL server to use its system-assigned identity to authenticate to the Storage account using Microsoft Entra ID, which is more secure than using an access key or shared access signature (SAS).
+  storage_account_access_key = null
+  storage_container_sas_key  = null
+
   recurring_scans {
     enabled                   = var.vulnerability_assessment_recurring_scans_enabled
     email_subscription_admins = var.vulnerability_assessment_recurring_scans_email_subscription_admins


### PR DESCRIPTION
Add comment to clarify that this module uses the system-assigned identity of the SQL server to authenticate to the Storage account using Microsoft Entra ID, which is more secure than using an access key or shared access signature (SAS).