### PR TITLE
fix: argument `metric` for resource `azurerm_monitor_diagnostic_setting` has been deprecated

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,20 +78,6 @@ resource "azurerm_monitor_diagnostic_setting" "server" {
   }
 
   # Metrics are not supported at the master database scope.
-  metric {
-    category = "Basic"
-    enabled  = false
-  }
-
-  metric {
-    category = "InstanceAndAppAdvanced"
-    enabled  = false
-  }
-
-  metric {
-    category = "WorkloadManagement"
-    enabled  = false
-  }
 
   depends_on = [
     # Wait for server extended auditing policy to be created.

--- a/modules/database/main.tf
+++ b/modules/database/main.tf
@@ -1,7 +1,3 @@
-locals {
-  diagnostic_setting_metric_categories = ["Basic", "InstanceAndAppAdvanced", "WorkloadManagement"]
-}
-
 resource "azurerm_mssql_database" "this" {
   name                           = var.database_name
   server_id                      = var.server_id
@@ -77,13 +73,11 @@ resource "azurerm_monitor_diagnostic_setting" "database" {
     }
   }
 
-  dynamic "metric" {
-    for_each = toset(concat(local.diagnostic_setting_metric_categories, var.diagnostic_setting_enabled_metric_categories))
+  dynamic "enabled_metric" {
+    for_each = toset(var.diagnostic_setting_enabled_metric_categories)
 
     content {
-      # Azure expects explicit configuration of both enabled and disabled metric categories.
       category = metric.value
-      enabled  = contains(var.diagnostic_setting_enabled_metric_categories, metric.value)
     }
   }
 }

--- a/modules/database/versions.tf
+++ b/modules/database/versions.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
-      version = ">= 3.87.0"
+      source = "hashicorp/azurerm"
+      # Version 4.31.0 is required to use the "enabled_metric" argument for the "azurerm_monitor_diagnostic_setting" resource.
+      version = ">= 4.31.0"
     }
   }
 }


### PR DESCRIPTION
- Replace argument `metric` with `enabled_metric`.
- Bump minimum allowed Azure provider version. Version 4.31.0 is required to use the `enabled_metric` argument.