### PR TITLE
feat!: migrate to express vulnerability configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,11 @@
+name: Test
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    name: Unit Tests
+    uses: equinor/terraform-baseline/.github/workflows/terraform-test.yml@main
+    with:
+      test-filter: tests/unit.tftest.hcl

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ module "sql" {
   resource_group_name        = azurerm_resource_group.example.name
   location                   = azurerm_resource_group.example.location
   log_analytics_workspace_id = module.log_analytics.workspace_id
-  storage_account_id         = module.storage.account_id
 
   azuread_administrator_login_username = "EntraAdmin"
   azuread_administrator_object_id      = "8954d564-505c-4cf8-a254-69e3b0facff2"
@@ -53,15 +52,6 @@ module "log_analytics" {
   location            = azurerm_resource_group.example.location
 }
 
-module "storage" {
-  source  = "equinor/storage/azurerm"
-  version = "~> 12.0"
-
-  account_name               = "sqlstorage"
-  resource_group_name        = azurerm_resource_group.example.name
-  location                   = azurerm_resource_group.example.location
-  log_analytics_workspace_id = module.log_analytics.workspace_id
-}
 ```
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Terraform module which creates Azure SQL resources.
 - Microsoft Entra administrator enforced.
 - Microsoft Entra-only authentication enabled by default.
 - Audit logs sent to given Log Analytics workspace by default.
-- Vulnerability assessment scan results stored in given Storage account.
+- Vulnerability assessment scan express configuration enabled.
 
 ## Prerequisites
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -35,7 +35,6 @@ module "sql" {
   resource_group_name        = var.resource_group_name
   location                   = var.location
   log_analytics_workspace_id = module.log_analytics.workspace_id
-  storage_account_id         = module.storage.account_id
 
   azuread_administrator_login_username = "azureadadminlogin"
   azuread_administrator_object_id      = data.azurerm_client_config.current.object_id

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -11,7 +11,8 @@ resource "random_id" "this" {
 }
 
 module "log_analytics" {
-  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.5.0"
+  source  = "equinor/log-analytics/azurerm"
+  version = "2.4.3"
 
   workspace_name      = "log-${random_id.this.hex}"
   resource_group_name = var.resource_group_name
@@ -19,7 +20,8 @@ module "log_analytics" {
 }
 
 module "storage" {
-  source = "github.com/equinor/terraform-azurerm-storage?ref=v11.0.0"
+  source  = "equinor/storage/azurerm"
+  version = "12.13.3"
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name
@@ -28,7 +30,8 @@ module "storage" {
 }
 
 module "sql" {
-  # source = "github.com/equinor/terraform-azurerm-sql?ref=v0.0.0"
+  # source  = "equinor/sql/azurerm"
+  # version = "0.0.0"
   source = "../.."
 
   server_name                = "sql-${random_id.this.hex}"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -17,7 +17,8 @@ resource "random_id" "this" {
 }
 
 module "log_analytics" {
-  source = "github.com/equinor/terraform-azurerm-log-analytics?ref=v1.5.0"
+  source  = "equinor/log-analytics/azurerm"
+  version = "2.4.3"
 
   workspace_name      = "log-${random_id.this.hex}"
   resource_group_name = var.resource_group_name
@@ -25,7 +26,8 @@ module "log_analytics" {
 }
 
 module "storage" {
-  source = "github.com/equinor/terraform-azurerm-storage?ref=v10.3.0"
+  source  = "equinor/storage/azurerm"
+  version = "12.13.3"
 
   account_name               = "st${random_id.this.hex}"
   resource_group_name        = var.resource_group_name
@@ -34,7 +36,8 @@ module "storage" {
 }
 
 module "sql" {
-  # source = "github.com/equinor/terraform-azurerm-sql?ref=v0.0.0"
+  # source  = "equinor/sql/azurerm"
+  # version = "0.0.0"
   source = "../.."
 
   server_name                = "sql-${random_id.this.hex}"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -41,7 +41,6 @@ module "sql" {
   resource_group_name        = var.resource_group_name
   location                   = var.location
   log_analytics_workspace_id = module.log_analytics.workspace_id
-  storage_account_id         = module.storage.account_id
 
   azuread_administrator_login_username = "azureadadminlogin"
   azuread_administrator_object_id      = data.azurerm_client_config.current.object_id
@@ -56,9 +55,6 @@ module "sql" {
       end_ip_address   = "0.0.0.0"
     }
   }
-
-  security_alert_policy_email_account_admins = true
-  security_alert_policy_email_addresses      = []
 
   tags = local.tags
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,7 +1,4 @@
 locals {
-  storage_account_name  = provider::azurerm::parse_resource_id(var.storage_account_id).resource_name
-  storage_blob_endpoint = "https://${local.storage_account_name}.blob.core.windows.net/"
-
   firewall_rules = var.firewall_rules_allow_azure_services ? {
     # Allow connections from inside Azure.
     # Ref: https://github.com/MicrosoftDocs/sql-docs/blob/2921bf7c9d2301d818479eae0488285403f48250/azure-sql/database/firewall-configure.md#connections-from-inside-azure

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,13 +23,3 @@ output "administrator_password" {
   value       = azurerm_mssql_server.this.administrator_login_password
   sensitive   = true
 }
-
-output "server_security_alert_policy_id" {
-  description = "The ID of the security alert policy for this SQL server."
-  value       = azurerm_mssql_server_security_alert_policy.this.id
-}
-
-output "server_vulnerability_assessment_id" {
-  description = "The ID of the vulnerability assessment for this SQL server."
-  value       = azurerm_mssql_server_vulnerability_assessment.this.id
-}

--- a/tests/setup-unit-tests/cloud-init.txt
+++ b/tests/setup-unit-tests/cloud-init.txt
@@ -1,0 +1,4 @@
+#cloud-config
+
+bootcmd:
+  - echo "Hello, world"! > hello.txt

--- a/tests/setup-unit-tests/cloud-init.txt
+++ b/tests/setup-unit-tests/cloud-init.txt
@@ -1,4 +1,0 @@
-#cloud-config
-
-bootcmd:
-  - echo "Hello, world"! > hello.txt

--- a/tests/setup-unit-tests/main.tf
+++ b/tests/setup-unit-tests/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6.0"
+    }
+  }
+}
+
+resource "random_id" "name_suffix" {
+  byte_length = 8
+}
+
+resource "random_uuid" "subscription_id" {}
+resource "random_uuid" "azuread_administrator_object_id" {}
+locals {
+  name_suffix                     = random_id.name_suffix.hex
+  subscription_id                 = random_uuid.subscription_id.result
+  resource_group_name             = "rg-${local.name_suffix}"
+  server_name                     = "sql-${local.name_suffix}"
+  log_analytics_workspace_name    = "log-${local.name_suffix}"
+  azuread_administrator_object_id = random_uuid.azuread_administrator_object_id.result
+
+}

--- a/tests/setup-unit-tests/outputs.tf
+++ b/tests/setup-unit-tests/outputs.tf
@@ -1,0 +1,34 @@
+output "resource_group_name" {
+  value = local.resource_group_name
+}
+
+output "location" {
+  value = "northeurope"
+}
+
+output "administrator_login" {
+  value = "azureadminuser"
+}
+
+output "log_analytics_workspace_id" {
+  value = "/subscriptions/${local.subscription_id}/resourceGroups/${local.resource_group_name}/providers/Microsoft.OperationalInsights/workspaces/${local.log_analytics_workspace_name}"
+}
+
+output "azuread_administrator_login_username" {
+  value = "azureadadminuser"
+}
+
+output "azuread_administrator_object_id" {
+  value = local.azuread_administrator_object_id
+}
+
+output "subscription_id" {
+  value = local.subscription_id
+}
+
+output "server_name" {
+  value = local.server_name
+}
+output "log_analytics_workspace_name" {
+  value = local.log_analytics_workspace_name
+}

--- a/tests/unit.tftest.hcl
+++ b/tests/unit.tftest.hcl
@@ -1,0 +1,46 @@
+mock_provider "azurerm" {}
+
+run "setup_tests" {
+  module {
+    source = "./tests/setup-unit-tests"
+  }
+}
+
+run "sql_server_azuread_authentication_only_enabled" {
+  command = plan
+
+  variables {
+    server_name                          = run.setup_tests.server_name
+    resource_group_name                  = run.setup_tests.resource_group_name
+    location                             = run.setup_tests.location
+    log_analytics_workspace_id           = run.setup_tests.log_analytics_workspace_id
+    azuread_administrator_login_username = run.setup_tests.azuread_administrator_login_username
+    azuread_administrator_object_id      = run.setup_tests.azuread_administrator_object_id
+    azuread_authentication_only          = true
+  }
+
+  assert {
+    condition     = azurerm_mssql_server.this.azuread_administrator[0].login_username == run.setup_tests.azuread_administrator_login_username && azurerm_mssql_server.this.azuread_administrator[0].azuread_authentication_only == true
+    error_message = "AzureAD authentication only not enabled"
+  }
+}
+
+run "sql_server_azuread_authentication_only_disabled" {
+  command = plan
+
+  variables {
+    server_name                          = run.setup_tests.server_name
+    resource_group_name                  = run.setup_tests.resource_group_name
+    location                             = run.setup_tests.location
+    log_analytics_workspace_id           = run.setup_tests.log_analytics_workspace_id
+    administrator_login                  = run.setup_tests.administrator_login
+    azuread_administrator_login_username = run.setup_tests.azuread_administrator_login_username
+    azuread_administrator_object_id      = run.setup_tests.azuread_administrator_object_id
+    azuread_authentication_only          = false
+  }
+
+  assert {
+    condition     = azurerm_mssql_server.this.administrator_login == run.setup_tests.administrator_login && azurerm_mssql_server.this.azuread_administrator[0].azuread_authentication_only == false
+    error_message = "AzureAD authentication only not disabled"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -18,24 +18,6 @@ variable "log_analytics_workspace_id" {
   type        = string
 }
 
-variable "storage_account_id" {
-  description = "The ID of the Storage account to use for SQL vulnerability assessment."
-  type        = string
-}
-
-variable "storage_blob_endpoint" {
-  description = "The blob endpoint of the Storage account to use for SQL vulnerability assessment."
-  type        = string
-  nullable    = true
-  default     = null
-}
-
-variable "storage_container_name" {
-  description = "The name of the Storage container to use for SQL vulnerability assessment."
-  type        = string
-  default     = "vulnerability-assessment"
-}
-
 variable "azuread_administrator_login_username" {
   description = "The login username of the Microsoft Entra administrator for this SQL server."
   type        = string
@@ -102,36 +84,6 @@ variable "diagnostic_setting_enabled_log_categories" {
     condition     = alltrue([for category in var.diagnostic_setting_enabled_log_categories : contains(["SQLSecurityAuditEvents", "DevOpsOperationsAudit"], category)])
     error_message = "Supported log categories are \"SQLSecurityAuditEvents\" and \"DevOpsOperationsAudit\"."
   }
-}
-
-variable "security_alert_policy_email_account_admins" {
-  description = "Should security alerts for this SQL server be sent to subscription owners?"
-  type        = bool
-  default     = false
-}
-
-variable "security_alert_policy_email_addresses" {
-  description = "A list of email addresses to send security alerts for this SQL server to."
-  type        = list(string)
-  default     = []
-}
-
-variable "vulnerability_assessment_recurring_scans_enabled" {
-  description = "Should SQL vulnerability assessment recurring scans be enabled?"
-  type        = bool
-  default     = true
-}
-
-variable "vulnerability_assessment_recurring_scans_email_subscription_admins" {
-  description = "Should notifications for SQL vulnerability assessment recurring scans be sent to subscription owners?"
-  type        = bool
-  default     = true
-}
-
-variable "vulnerability_assessment_recurring_scans_emails" {
-  description = "A list of email addresses to send notifications for SQL vulnerability assessment recurring scans to."
-  type        = list(string)
-  default     = []
 }
 
 variable "tags" {

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     azurerm = {
-      source  = "hashicorp/azurerm"
+      source = "hashicorp/azurerm"
       # Exluding Azure provider version v4.31 due to a breaking change making optional arguments, only working in certain scenarios, required.
       # Will keep this version excluded until fix is availiable. Ref.: https://github.com/hashicorp/terraform-provider-azurerm/pull/29789
       version = ">= 4.0.0, != 4.31.0"


### PR DESCRIPTION
https://github.com/equinor/terraform-baseline/issues/203

BREAKING CHANGE: remove variable `storage_account_id`. To migrate your project, remove any references to this variable.

BREAKING CHANGE: remove variable `storage_blob_endpoint`. To migrate your project, remove any references to this variable.

BREAKING CHANGE: remove variable `storage_container_name`. To migrate your project, remove any references to this variable.

BREAKING CHANGE: remove variable `security_alert_policy_email_account_admins`. To migrate your project, remove any references to this variable.

BREAKING CHANGE: remove variable `security_alert_policy_email_addresses`. To migrate your project, remove any references to this variable.

BREAKING CHANGE: remove variable `vulnerability_assessment_recurring_scans_enabled`. To migrate your project, remove any references to this variable.

BREAKING CHANGE: remove variable `vulnerability_assessment_recurring_scans_email_subscription_admins`. To migrate your project, remove any references to this variable.

BREAKING CHANGE: remove variable `vulnerability_assessment_recurring_scans_emails`. To migrate your project, remove any references to this variable.

BREAKING CHANGE: remove output `server_security_alert_policy_id`. To migrate your project, remove any references to this output.

BREAKING CHANGE: remove output `server_vulnerability_assessment_id`. To migrate your project, remove any references to this output.