### PR TITLE
fix: incorrect required Azure provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,9 +4,9 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      # Exluding Azure provider version v4.31 due to a breaking change making optional arguments, only working in certain scenarios, required.
-      # Will keep this version excluded until fix is availiable. Ref.: https://github.com/hashicorp/terraform-provider-azurerm/pull/29789
-      version = ">= 4.0.0, != 4.31.0"
+      # Version 4.26.0 is required to use the "express_vulnerability_assessment_enabled" argument for the "azurerm_mssql_server" resource.
+      # Ref: https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v4.26.0
+      version = ">= 4.26.0"
     }
 
     random = {


### PR DESCRIPTION
v4.26.0 required to use the `express_vulnerability_assessment_enabled` argument for the `azurerm_mssql_server` resource.

v4.31.0 should no longer be excluded. It was excluded due to a breaking change in the `azurerm_mssql_server_vulnerability_assessment` resource, however that resource was removed in v12.0.0 of this module.